### PR TITLE
Fix button style on iOS

### DIFF
--- a/src/components/styles/EntryPoint.styles.ts
+++ b/src/components/styles/EntryPoint.styles.ts
@@ -14,6 +14,7 @@ export const containerStyles: BoxStyleProps = {
     cursor: "pointer",
     transition: "background-color 0.2s",
     outline: "0px",
+    padding: "space0",
     _hover: {
         backgroundColor: "colorBackgroundPrimaryStronger"
     },


### PR DESCRIPTION
Mobile Safari adds some padding to inputs that was not accounted for here.

I'll attempt to get this merged upstream as well.