### PR TITLE
Fix mime type file extension checks

### DIFF
--- a/src/components/FilePreview.tsx
+++ b/src/components/FilePreview.tsx
@@ -7,7 +7,7 @@ import { FileIcon } from "@twilio-paste/icons/esm/FileIcon";
 import { CloseIcon } from "@twilio-paste/icons/esm/CloseIcon";
 import { Button } from "@twilio-paste/core/button";
 import { Media } from "@twilio/conversations";
-import { extension as mimeToExtension } from "mime-types";
+import { extensions as mimeToExtensions } from "mime-types";
 import { Truncate } from "@twilio-paste/core/truncate";
 
 import { addNotification, detachFiles } from "../store/actions/genericActions";
@@ -58,7 +58,11 @@ export const FilePreview = (props: FilePreviewProps) => {
 
         if (
             fileAttachmentConfig?.acceptedExtensions &&
-            !fileAttachmentConfig.acceptedExtensions.includes(mimeToExtension(file.type) as string)
+            !mimeToExtensions[file.type].some(
+                (type) =>
+                    fileAttachmentConfig?.acceptedExtensions &&
+                    fileAttachmentConfig.acceptedExtensions.indexOf(type) >= 0
+            )
         ) {
             dispatch(
                 addNotification(

--- a/src/utils/validateFiles.ts
+++ b/src/utils/validateFiles.ts
@@ -1,4 +1,4 @@
-import { extension as mimeToExtension } from "mime-types";
+import { extensions as mimeToExtensions } from "mime-types";
 import { Dispatch } from "redux";
 
 import { addNotification } from "../store/actions/genericActions";
@@ -44,7 +44,11 @@ export const validateFiles = (
             );
         } else if (
             fileAttachmentConfig?.acceptedExtensions &&
-            !fileAttachmentConfig.acceptedExtensions.includes(mimeToExtension(file.type) as string)
+            !mimeToExtensions[file.type].some(
+                (type) =>
+                    fileAttachmentConfig?.acceptedExtensions &&
+                    fileAttachmentConfig.acceptedExtensions.indexOf(type) >= 0
+            )
         ) {
             dispatch(
                 addNotification(


### PR DESCRIPTION
Presently, the attachment's mime-type is converted to a file extension, which is then compared to the list of allowed extensions. However, for files such as mp3 with mime type "audio/mpeg", there are multiple allowed file extensions, so the mime-to-extension conversion results in an extension that is not allowed, preventing the file from being accessed, even though the file extension is mp3.

This fixes that problem by getting the full list of extensions for a mime type, rather than simply the default, and then checking if an extension from that list is in the allowed extensions.

I will also be submitting this upstream.